### PR TITLE
Changed react-router peerDependecy version to '*'

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Google analytics component for react-router",
   "main": "src/index.js",
   "peerDependencies": {
-    "react-router": "^0.11.x"
+    "react-router": "*"
   },
   "author": "Thomas Coopman @tcoopman",
   "repository": {


### PR DESCRIPTION
Changing version to '*' resolved version conflict issue  https://github.com/tcoopman/ga-react-router/issues/1
