### PR TITLE
Optionally pass anonymizeIp to ga

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,10 @@
 var ga = require('./ga');
 
 
-function analytics(state) {
+function analytics(state, anonymizeIp) {
   ga('send', 'pageview', {
-    'page': state.path
+    'page': state.path,
+    'anonymizeIp': anonymizeIp
   });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,12 @@
 var ga = require('./ga');
 
 
-function analytics(state, anonymizeIp) {
-  ga('send', 'pageview', {
-    'page': state.path,
-    'anonymizeIp': anonymizeIp
-  });
+function analytics(state, options) {
+  if (!options) {
+    options = {};
+  }
+  options.page = state.path;
+  ga('send', 'pageview', options);
 }
 
 


### PR DESCRIPTION
Google analytics allows to anonymize the IP address.
https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced#anonymizeip

German law requires that as far as I know and with the one line in my commit ga-react-router optionally allows to use that feature :)

Can you merge it?
